### PR TITLE
gem install thin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ PostBin, a simple web service for testing WebHooks (HTTP POST requests).
 Quick Start
 -----------
 
-    $ gem install postbin
+    $ gem install postbin thin
     $ postbin
     == Starting PostBin on http://127.0.0.1:6969
     == Sinatra/1.3.1 has taken the stage on 6969 for development with backup from Thin


### PR DESCRIPTION
Suggesting docs improvement; but perhaps `thin` needs to go in `postbin`'s gemspec?

```
$ gem install postbin
Fetching multi_json-1.14.1.gem
Fetching postbin-0.1.6.gem
$ postbin
== Starting PostBin on http://127.0.0.1:6969
...
Server handler (thin) not found.

$ gem install thin
$ postbin
== Starting PostBin on http://127.0.0.1:6969
== Sinatra (v2.0.8.1) has taken the stage on 6969 for development with backup from Thin
Thin web server (v1.7.2 codename Bachmanity)
```